### PR TITLE
Add abort check on DigitalOutput, BinaryActuator On/Off entry

### DIFF
--- a/ControlBee/Models/BinaryActuator.cs
+++ b/ControlBee/Models/BinaryActuator.cs
@@ -189,6 +189,8 @@ public class BinaryActuator : ActorItem, IBinaryActuator
 
     private void SetOn(bool on)
     {
+        if (IsAborted())
+            throw new DeviceAbortedError();
         Wait();
         if (ActualOn == on)
             return;
@@ -208,8 +210,6 @@ public class BinaryActuator : ActorItem, IBinaryActuator
             var watch = _timeManager.CreateWatch();
             while (true)
             {
-                if (IsAborted())
-                    return false;
                 if (CommandOn && OnDetect())
                     break;
                 if (!CommandOn && OffDetect())

--- a/ControlBee/Models/DigitalOutput.cs
+++ b/ControlBee/Models/DigitalOutput.cs
@@ -72,6 +72,8 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
 
     protected virtual void SetOnImpl(bool on)
     {
+        if (IsAborted())
+            throw new DeviceAbortedError();
         if (CommandOn == on)
             return;
         CommandOn = on;
@@ -82,8 +84,6 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
             var watch = timeManager.CreateWatch();
             while (true)
             {
-                if (IsAborted())
-                    return;
                 if (watch.ElapsedMilliseconds >= delay)
                     break;
 


### PR DESCRIPTION
## What
- DigitalOutput, BinaryActuator 의 On/Off 명령 하달 시 Abort 감지

## Why
- DigitalOutput BinaryActuator 에 abort error throw 조건을 wait에만 걸어서 단순 On/Off 시 abort throw가 되지 않음

## How
- SetOnImpl 진입 시 Abort 확인 후 Error Throw