### PR TITLE
Add SafeState option for DigitalOutput on abort

### DIFF
--- a/ControlBee/Constants/OutputSafeState.cs
+++ b/ControlBee/Constants/OutputSafeState.cs
@@ -1,0 +1,8 @@
+namespace ControlBee.Constants;
+
+public enum OutputSafeState
+{
+    None,
+    On,
+    Off,
+}

--- a/ControlBee/Models/DeviceChannel.cs
+++ b/ControlBee/Models/DeviceChannel.cs
@@ -14,9 +14,19 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
 
     private static readonly Dictionary<string, DeviceMetaInfo> DeviceMetaInfoMap = [];
     private readonly DeviceMetaInfo _localDeviceMetaInfo = new();
-    private bool _subscribedToDeviceMetaInfo;
+    private IDevice? _device;
 
-    protected IDevice? Device { get; set; }
+    protected IDevice? Device
+    {
+        get => _device;
+        set
+        {
+            _device = value;
+            if (_device != null)
+                GetDeviceMetaInfo().PropertyChanged += OnDeviceMetaInfoChanged;
+        }
+    }
+
     protected string? DeviceName { get; set; }
     protected int Channel { get; set; } = -1;
 
@@ -84,7 +94,6 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
         }
 
         Device = deviceManager.Get(DeviceName!);
-        SubscribeToDeviceMetaInfoIfNeeded();
     }
 
     public void SetChannel(int channel)
@@ -96,15 +105,6 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
     {
         DeviceName = deviceName;
         Device = deviceManager.Get(DeviceName!);
-        SubscribeToDeviceMetaInfoIfNeeded();
-    }
-
-    private void SubscribeToDeviceMetaInfoIfNeeded()
-    {
-        if (_subscribedToDeviceMetaInfo)
-            return;
-        GetDeviceMetaInfo().PropertyChanged += OnDeviceMetaInfoChanged;
-        _subscribedToDeviceMetaInfo = true;
     }
 
     private void OnDeviceMetaInfoChanged(object? sender, PropertyChangedEventArgs e)

--- a/ControlBee/Models/DeviceChannel.cs
+++ b/ControlBee/Models/DeviceChannel.cs
@@ -1,4 +1,5 @@
-﻿using ControlBee.Interfaces;
+﻿using System.ComponentModel;
+using ControlBee.Interfaces;
 using ControlBeeAbstract.Devices;
 using log4net;
 
@@ -13,6 +14,7 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
 
     private static readonly Dictionary<string, DeviceMetaInfo> DeviceMetaInfoMap = [];
     private readonly DeviceMetaInfo _localDeviceMetaInfo = new();
+    private bool _subscribedToDeviceMetaInfo;
 
     protected IDevice? Device { get; set; }
     protected string? DeviceName { get; set; }
@@ -82,6 +84,7 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
         }
 
         Device = deviceManager.Get(DeviceName!);
+        SubscribeToDeviceMetaInfoIfNeeded();
     }
 
     public void SetChannel(int channel)
@@ -93,7 +96,26 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
     {
         DeviceName = deviceName;
         Device = deviceManager.Get(DeviceName!);
+        SubscribeToDeviceMetaInfoIfNeeded();
     }
+
+    private void SubscribeToDeviceMetaInfoIfNeeded()
+    {
+        if (_subscribedToDeviceMetaInfo)
+            return;
+        GetDeviceMetaInfo().PropertyChanged += OnDeviceMetaInfoChanged;
+        _subscribedToDeviceMetaInfo = true;
+    }
+
+    private void OnDeviceMetaInfoChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(DeviceMetaInfo.Aborted))
+            return;
+        if (GetDeviceMetaInfo().Aborted)
+            OnDeviceAborted();
+    }
+
+    protected virtual void OnDeviceAborted() { }
 
     protected DeviceMetaInfo GetDeviceMetaInfo()
     {

--- a/ControlBee/Models/DigitalOutput.cs
+++ b/ControlBee/Models/DigitalOutput.cs
@@ -20,6 +20,7 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
     private Task? _task;
     public Variable<int> OffDelay = new(VariableScope.Global, 0);
     public Variable<int> OnDelay = new(VariableScope.Global, 0);
+    public OutputSafeState SafeState = OutputSafeState.None;
 
     protected virtual IDigitalIoDevice? DigitalIoDevice => Device as IDigitalIoDevice;
 
@@ -72,8 +73,6 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
 
     protected virtual void SetOnImpl(bool on)
     {
-        if (IsAborted())
-            throw new DeviceAbortedError();
         if (CommandOn == on)
             return;
         CommandOn = on;
@@ -101,6 +100,8 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
             Logger.Debug("DigitalIoDevice is null.");
             return;
         }
+        if (IsAborted())
+            throw new DeviceAbortedError();
 
         SetOnImpl(on);
     }
@@ -161,6 +162,31 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
     {
         base.PostInit();
         Sync();
+    }
+
+    public override void InjectProperties(ISystemPropertiesDataSource dataSource)
+    {
+        base.InjectProperties(dataSource);
+        if (dataSource.GetValue(ActorName, ItemPath, nameof(SafeState)) is string safeState)
+            Enum.TryParse(safeState, ignoreCase: true, out SafeState);
+    }
+
+    protected override void OnDeviceAborted()
+    {
+        if (DigitalIoDevice == null)
+            return;
+        if (SafeState == OutputSafeState.None)
+            return;
+        Logger.Info($"Apply SafeState on abort. ({ActorName}, {ItemPath}, {Channel}, {SafeState})");
+        switch (SafeState)
+        {
+            case OutputSafeState.On:
+                SetOnImpl(true);
+                break;
+            case OutputSafeState.Off:
+                SetOnImpl(false);
+                break;
+        }
     }
 
     private void DigitalIoDeviceOnReconnected(object? sender, EventArgs e)


### PR DESCRIPTION
## What
- DigitalOutput에 device abort 시 자동 적용될 SafeState(None/On/Off) 옵션 추가

## Why
- device abort 상태에서는 SW 명령(SetOn)이 DeviceAbortedError를 throw하여 output을 제어할 수 없음
- On상태 일 경우 계속 출력이 지속되는 Output이 존재하기 때문에 On 상태에서 Abort가 트리거 시 설비 문제로 이어질 수 있음. 따라서 Abort 시 Value를 강제로 특정 값으로 설정하는 옵션이 필요함.

## How
- OutputSafeState enum 추가 (None/On/Off, 기본값 None이라 하위 호환)
- DigitalOutput: SafeState 필드 + InjectProperties override로 YAML에서 읽음
- DeviceChannel: DeviceMetaInfo.PropertyChanged 구독, Aborted=true 이벤트 시 OnDeviceAborted virtual 호출. 중복 구독
방지 플래그 포함
- DigitalOutput.OnDeviceAborted override: SafeState에 따라 SetOnImpl 직접 호출 + Logger.Info
- SetOnImpl의 IsAborted throw 체크를 SetOn으로 이동 (DigitalIoDevice null 체크 아래)

실 장비 검증 완료