### PR TITLE
Make BinaryActuator polling task abort-aware

### DIFF
--- a/ControlBee/Models/BinaryActuator.cs
+++ b/ControlBee/Models/BinaryActuator.cs
@@ -210,6 +210,8 @@ public class BinaryActuator : ActorItem, IBinaryActuator
             var watch = _timeManager.CreateWatch();
             while (true)
             {
+                if (IsAborted())
+                    return false;
                 if (CommandOn && OnDetect())
                     break;
                 if (!CommandOn && OffDetect())


### PR DESCRIPTION
## What
- BinaryActuator.SetOn의 _task while 루프에 abort 처리 추가

## Why
- 루프가 IsAborted를 보지 않아 Abort 후에도 polling이 timeout까지 계속됨. 그 사이 Aborted 플래그가 풀리면 Wait()이 abort로 인지하지 못하고 TimeoutError를 throw함

## How
- 루프 첫 줄에 `if (IsAborted()) return false;` 추가