### PR TITLE
Add IgnoreAbort flag to DigitalOutput for per-channel abort opt-out

### DIFF
--- a/ControlBee/Models/DeviceChannel.cs
+++ b/ControlBee/Models/DeviceChannel.cs
@@ -124,7 +124,7 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
         return deviceManager.GetDeviceMetaInfo(DeviceName);
     }
 
-    public bool IsAborted()
+    public virtual bool IsAborted()
     {
         return GetDeviceMetaInfo().Aborted;
     }

--- a/ControlBee/Models/DigitalOutput.cs
+++ b/ControlBee/Models/DigitalOutput.cs
@@ -21,6 +21,7 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
     public Variable<int> OffDelay = new(VariableScope.Global, 0);
     public Variable<int> OnDelay = new(VariableScope.Global, 0);
     public OutputSafeState SafeState = OutputSafeState.None;
+    public bool IgnoreAbort = false;
 
     protected virtual IDigitalIoDevice? DigitalIoDevice => Device as IDigitalIoDevice;
 
@@ -169,11 +170,22 @@ public class DigitalOutput(IDeviceManager deviceManager, ITimeManager timeManage
         base.InjectProperties(dataSource);
         if (dataSource.GetValue(ActorName, ItemPath, nameof(SafeState)) is string safeState)
             Enum.TryParse(safeState, ignoreCase: true, out SafeState);
+        if (dataSource.GetValue(ActorName, ItemPath, nameof(IgnoreAbort)) is string ignoreAbort)
+            bool.TryParse(ignoreAbort, out IgnoreAbort);
+    }
+
+    public override bool IsAborted()
+    {
+        if (IgnoreAbort)
+            return false;
+        return base.IsAborted();
     }
 
     protected override void OnDeviceAborted()
     {
         if (DigitalIoDevice == null)
+            return;
+        if (IgnoreAbort)
             return;
         if (SafeState == OutputSafeState.None)
             return;


### PR DESCRIPTION
## What
- DigitalOutput에 채널별 abort 무시 플래그 `IgnoreAbort` 추가

## Why
- `AbortDevice()`는 `DeviceMetaInfo.Aborted`를 디바이스 단위로 세팅 → 같은 디바이스의 모든 채널이 일괄 abort 대상
- 그러나 abort 본래 목적은 안전을 이유로 한 강제 중단인데, 안전과 무관한 출력(버저, 알람 LED 등)까지 조작이 안되면 문제가 있음
- DigitalOutput 단위로 abort 동작에서 빠질 수 있는 opt-out이 필요. Axis나 Input 타입은 abort opt-out이 안전상/의미상 적절치 않아 DigitalOutput 한정

## How
- `DigitalOutput.cs`에 `public bool IgnoreAbort = false;` 추가, `SafeState`와 동일하게 `InjectProperties`에서 시스템
프로퍼티로 주입
- `IsAborted()` override: `IgnoreAbort=true`면 false 반환 → `SetOn`/`Wait`의 throw 회피
- `OnDeviceAborted()` 진입부에 `IgnoreAbort` 가드 추가 → SafeState 자동 전환 스킵
- `DeviceChannel.IsAborted()`를 `virtual`로 변경 (override 가능하도록)