### PR TITLE
Add per-function executability framework for actors

### DIFF
--- a/ControlBee/Models/Actor.cs
+++ b/ControlBee/Models/Actor.cs
@@ -186,7 +186,23 @@ public class Actor : IActorInternal, IDisposable
 
     protected virtual bool IsFunctionExecutable(string functionName) => true;
 
-    protected void PublishFunctions()
+    protected virtual string[] ExecutabilityStatusKeys => [];
+
+    private bool ExecutabilityDependencyChanged(Message message)
+    {
+        if (ExecutabilityStatusKeys.Length == 0)
+            return false;
+
+        if (!PeerStatus.TryGetValue(message.Sender, out var oldStatus))
+            return true;
+
+        var newStatus = message.DictPayload!;
+        return ExecutabilityStatusKeys.Any(key =>
+            !Equals(oldStatus.GetValueOrDefault(key), newStatus.GetValueOrDefault(key))
+        );
+    }
+
+    protected void PublishExecutableFunctions()
     {
         var dict = new Dict();
         foreach (var functionName in GetFunctions())
@@ -622,6 +638,9 @@ public class Actor : IActorInternal, IDisposable
             return false;
         }
 
+        var executabilityAffected =
+            message.Name == "_status" && ExecutabilityDependencyChanged(message);
+
         var result = ActorBuiltinMessageHandler.ProcessMessage(message);
         result |= State.ProcessMessage(message);
         if (message is ActorItemMessage actorItemMessage)
@@ -629,6 +648,9 @@ public class Actor : IActorInternal, IDisposable
             var item = GetItem(actorItemMessage.ItemPath);
             result |= item?.ProcessMessage(actorItemMessage) ?? false;
         }
+
+        if (executabilityAffected)
+            PublishExecutableFunctions();
 
         return result;
     }

--- a/ControlBee/Models/Actor.cs
+++ b/ControlBee/Models/Actor.cs
@@ -184,21 +184,29 @@ public class Actor : IActorInternal, IDisposable
         return GetRegisteredFunctions().Where(IsFunctionAvailable).ToArray();
     }
 
-    private bool IsFunctionExecutable(string functionName)
+    protected virtual bool IsFunctionExecutable(string functionName) => true;
+
+    protected void PublishFunctions()
     {
+        var dict = new Dict();
+        foreach (var functionName in GetFunctions())
+            dict[functionName] = IsFunctionExecutable(functionName);
+
         lock (_statusLock)
         {
             if (
-                Status.GetValueOrDefault("_executableFunctions") is Dict dict
-                && dict.TryGetValue(functionName, out var value)
+                Status.GetValueOrDefault("_executableFunctions") is Dict prev
+                && prev.Count == dict.Count
+                && prev.All(keyValuePair =>
+                    dict.TryGetValue(keyValuePair.Key, out var value)
+                    && Equals(value, keyValuePair.Value)
+                )
             )
-                return value is not false;
+                return;
         }
 
-        return true;
+        SetStatus("_executableFunctions", dict);
     }
-
-    protected internal virtual void PublishFunctions() { }
 
     public string[] GetAxisItemPaths(string positionItemPath)
     {

--- a/ControlBee/Models/Actor.cs
+++ b/ControlBee/Models/Actor.cs
@@ -186,7 +186,7 @@ public class Actor : IActorInternal, IDisposable
 
     protected virtual bool IsFunctionExecutable(string functionName) => true;
 
-    protected void PublishExecutableFunctions()
+    protected void PublishFunctions()
     {
         var dict = new Dict();
         foreach (var functionName in GetFunctions())
@@ -208,7 +208,7 @@ public class Actor : IActorInternal, IDisposable
         SetStatus("_executableFunctions", dict);
     }
 
-    internal void PublishExecutableFunctionsInternal() => PublishExecutableFunctions();
+    internal void PublishFunctionsInternal() => PublishFunctions();
 
     public string[] GetAxisItemPaths(string positionItemPath)
     {
@@ -743,6 +743,5 @@ public class Actor : IActorInternal, IDisposable
     protected virtual void OnStateChanged((IState oldState, IState newState) e)
     {
         StateChanged?.Invoke(this, e);
-        PublishExecutableFunctions();
     }
 }

--- a/ControlBee/Models/Actor.cs
+++ b/ControlBee/Models/Actor.cs
@@ -184,31 +184,21 @@ public class Actor : IActorInternal, IDisposable
         return GetRegisteredFunctions().Where(IsFunctionAvailable).ToArray();
     }
 
-    protected virtual bool IsFunctionExecutable(string functionName) => true;
-
-    protected void PublishFunctions()
+    private bool IsFunctionExecutable(string functionName)
     {
-        var dict = new Dict();
-        foreach (var functionName in GetFunctions())
-            dict[functionName] = IsFunctionExecutable(functionName);
-
         lock (_statusLock)
         {
             if (
-                Status.GetValueOrDefault("_executableFunctions") is Dict prev
-                && prev.Count == dict.Count
-                && prev.All(keyValuePair =>
-                    dict.TryGetValue(keyValuePair.Key, out var value)
-                    && Equals(value, keyValuePair.Value)
-                )
+                Status.GetValueOrDefault("_executableFunctions") is Dict dict
+                && dict.TryGetValue(functionName, out var value)
             )
-                return;
+                return value is not false;
         }
 
-        SetStatus("_executableFunctions", dict);
+        return true;
     }
 
-    internal void PublishFunctionsInternal() => PublishFunctions();
+    protected internal virtual void PublishFunctions() { }
 
     public string[] GetAxisItemPaths(string positionItemPath)
     {

--- a/ControlBee/Models/Actor.cs
+++ b/ControlBee/Models/Actor.cs
@@ -186,22 +186,6 @@ public class Actor : IActorInternal, IDisposable
 
     protected virtual bool IsFunctionExecutable(string functionName) => true;
 
-    protected virtual string[] ExecutabilityStatusKeys => [];
-
-    private bool ExecutabilityDependencyChanged(Message message)
-    {
-        if (ExecutabilityStatusKeys.Length == 0)
-            return false;
-
-        if (!PeerStatus.TryGetValue(message.Sender, out var oldStatus))
-            return true;
-
-        var newStatus = message.DictPayload!;
-        return ExecutabilityStatusKeys.Any(key =>
-            !Equals(oldStatus.GetValueOrDefault(key), newStatus.GetValueOrDefault(key))
-        );
-    }
-
     protected void PublishExecutableFunctions()
     {
         var dict = new Dict();
@@ -638,9 +622,6 @@ public class Actor : IActorInternal, IDisposable
             return false;
         }
 
-        var executabilityAffected =
-            message.Name == "_status" && ExecutabilityDependencyChanged(message);
-
         var result = ActorBuiltinMessageHandler.ProcessMessage(message);
         result |= State.ProcessMessage(message);
         if (message is ActorItemMessage actorItemMessage)
@@ -648,9 +629,6 @@ public class Actor : IActorInternal, IDisposable
             var item = GetItem(actorItemMessage.ItemPath);
             result |= item?.ProcessMessage(actorItemMessage) ?? false;
         }
-
-        if (executabilityAffected)
-            PublishExecutableFunctions();
 
         return result;
     }

--- a/ControlBee/Models/Actor.cs
+++ b/ControlBee/Models/Actor.cs
@@ -40,6 +40,7 @@ public class Actor : IActorInternal, IDisposable
     private string _title = string.Empty;
     public IDialog CrashError = new DialogPlaceholder();
     public IDialog FatalError = new DialogPlaceholder();
+    public IDialog FunctionNotExecutableError = new DialogPlaceholder();
 
     public PlatformException? ExitError;
 
@@ -69,6 +70,7 @@ public class Actor : IActorInternal, IDisposable
 
         ActorBuiltinMessageHandler = new ActorBuiltinMessageHandler(this);
         _mailbox.Add(new StateEntryMessage(this));
+        Status["_executableFunctions"] = new Dict();
     }
 
     public IState State
@@ -181,6 +183,32 @@ public class Actor : IActorInternal, IDisposable
     {
         return GetRegisteredFunctions().Where(IsFunctionAvailable).ToArray();
     }
+
+    protected virtual bool IsFunctionExecutable(string functionName) => true;
+
+    protected void PublishExecutableFunctions()
+    {
+        var dict = new Dict();
+        foreach (var functionName in GetFunctions())
+            dict[functionName] = IsFunctionExecutable(functionName);
+
+        lock (_statusLock)
+        {
+            if (
+                Status.GetValueOrDefault("_executableFunctions") is Dict prev
+                && prev.Count == dict.Count
+                && prev.All(keyValuePair =>
+                    dict.TryGetValue(keyValuePair.Key, out var value)
+                    && Equals(value, keyValuePair.Value)
+                )
+            )
+                return;
+        }
+
+        SetStatus("_executableFunctions", dict);
+    }
+
+    internal void PublishExecutableFunctionsInternal() => PublishExecutableFunctions();
 
     public string[] GetAxisItemPaths(string positionItemPath)
     {
@@ -587,6 +615,15 @@ public class Actor : IActorInternal, IDisposable
 
     protected virtual bool ProcessMessage(Message message)
     {
+        if (Array.IndexOf(GetFunctions(), message.Name) >= 0 && !IsFunctionExecutable(message.Name))
+        {
+            Logger.Warn(
+                $"Function '{message.Name}' is not executable. Rejecting message from {message.Sender?.Name}."
+            );
+            FunctionNotExecutableError.Show($"'{message.Name}' is not executable right now.");
+            return false;
+        }
+
         var result = ActorBuiltinMessageHandler.ProcessMessage(message);
         result |= State.ProcessMessage(message);
         if (message is ActorItemMessage actorItemMessage)
@@ -706,5 +743,6 @@ public class Actor : IActorInternal, IDisposable
     protected virtual void OnStateChanged((IState oldState, IState newState) e)
     {
         StateChanged?.Invoke(this, e);
+        PublishExecutableFunctions();
     }
 }

--- a/ControlBee/Models/ActorBuiltinMessageHandler.cs
+++ b/ControlBee/Models/ActorBuiltinMessageHandler.cs
@@ -34,7 +34,7 @@ public class ActorBuiltinMessageHandler(Actor actor)
 
                 foreach (var (key, value) in message.DictPayload!)
                     peerStatus[key] = value;
-                actor.PublishExecutableFunctionsInternal();
+                actor.PublishFunctionsInternal();
                 return true;
             }
             case "_propertyRead":

--- a/ControlBee/Models/ActorBuiltinMessageHandler.cs
+++ b/ControlBee/Models/ActorBuiltinMessageHandler.cs
@@ -34,7 +34,6 @@ public class ActorBuiltinMessageHandler(Actor actor)
 
                 foreach (var (key, value) in message.DictPayload!)
                     peerStatus[key] = value;
-                actor.PublishFunctions();
                 return true;
             }
             case "_propertyRead":

--- a/ControlBee/Models/ActorBuiltinMessageHandler.cs
+++ b/ControlBee/Models/ActorBuiltinMessageHandler.cs
@@ -34,7 +34,7 @@ public class ActorBuiltinMessageHandler(Actor actor)
 
                 foreach (var (key, value) in message.DictPayload!)
                     peerStatus[key] = value;
-                actor.PublishFunctionsInternal();
+                actor.PublishFunctions();
                 return true;
             }
             case "_propertyRead":

--- a/ControlBee/Models/ActorBuiltinMessageHandler.cs
+++ b/ControlBee/Models/ActorBuiltinMessageHandler.cs
@@ -34,6 +34,7 @@ public class ActorBuiltinMessageHandler(Actor actor)
 
                 foreach (var (key, value) in message.DictPayload!)
                     peerStatus[key] = value;
+                actor.PublishExecutableFunctionsInternal();
                 return true;
             }
             case "_propertyRead":


### PR DESCRIPTION
# What
- Actor에 pre-function executability 도입
- 각 actor가 자기 function의 실행 가능 여부를 동적으로 판단해서 (1) status로 publish하고 (2) message 수신 시 실행을 차단 + dialog

# Why
- UI gating 로직이 View에 흩어져 있음: WatchPeerStatus("SafeToRotate", peer1, peer2, …) 를 button마다 수동 wiring. Actor의 safety check 로직과 중복됨 (C사 H프로젝트)
- "실행 가능 여부"의 single source of truth가 필요: actor 자신이 자기 가용성을 결정하고, 그것이 UI와 runtime guard에 자동 전파되어야 함.

# How
- IsFunctionExecutable(name) virtual hook: actor가 override할 단일 진입점. 기본은 true.
- PublishExecutableFunctions(): GetFunctions() × IsFunctionExecutable 결과를 dict로 만들어 Status["_executableFunctions"] 에 SetStatus. element-wise 비교로 변화 없으면 skip.
- 자동 republish trigger 두 곳: (1) OnStateChanged 끝 → 자기 state 전이 시, (2) ActorBuiltinMessageHandler._status case → peer status 수신 시
- Runtime guard: ProcessMessage 진입부에서 message name이 GetFunctions() 안에 있고 IsFunctionExecutable == false 면 log warn + FunctionNotExecutableError.Show(...) + return false.
- FunctionNotExecutableError IDialog 필드: 기존 CrashError 패턴 그대로. framework가 자동 wiring.

# How to use
```
protected override bool IsFunctionExecutable(string functionName)
{
    return functionName switch
    {
        "Move" => GetPeerStatus(OtherActor, "Busy") is not true,
	"Rotate" => SafetyCheckingPeers.All(p => GetPeerStatus(p, "SafeToRotate") is true),
	"Trigger" => Cameras.Any(c => GetPeerStatus(c, "Connected") is true),
	"Pick" => GetStatus("Calibrated") is true,
        _ => true,                                     // 등록 안 한 function은 default true
    };
}
```