### PR TITLE
Extract SetSoftwareLimit from useClearPosition if statement

### DIFF
--- a/ControlBee/Sequences/InitializeSequence.cs
+++ b/ControlBee/Sequences/InitializeSequence.cs
@@ -64,16 +64,16 @@ public class InitializeSequence(
         {
             Thread.Sleep(DelayBeforeClearPosition.Value);
             axis.ClearPosition();
-
-            var useSoftwareLimit = axis.GetUseSoftwareLimit();
-            var negativeSoftwareLimitPosition = axis.GetNegativeSoftwareLimitPosition();
-            var positiveSoftwareLimitPosition = axis.GetPositiveSoftwareLimitPosition();
-            axis.SetSoftwareLimit(
-                useSoftwareLimit,
-                negativeSoftwareLimitPosition,
-                positiveSoftwareLimitPosition
-            );
         }
+
+        var useSoftwareLimit = axis.GetUseSoftwareLimit();
+        var negativeSoftwareLimitPosition = axis.GetNegativeSoftwareLimitPosition();
+        var positiveSoftwareLimitPosition = axis.GetPositiveSoftwareLimitPosition();
+        axis.SetSoftwareLimit(
+            useSoftwareLimit,
+            negativeSoftwareLimitPosition,
+            positiveSoftwareLimitPosition
+        );
 
         axis.SetSpeed(axis.GetJogSpeed(JogSpeedLevel.Fast));
         homePosition.Value.MoveAndWait();


### PR DESCRIPTION
## Why

AxisSensorType.None 인 경우에도 SoftwareLimit 을 설정하기 위함

## What

useClearPosition 와 별개로 SoftwareLimit 설정은 항상 되도록

## How

SetSoftwareLimit 관련 코드라인을 `if (useClearPosition)` 조건 밖으로 추출