### PR TITLE
Encapsulate DeviceMetaInfo abort behind Abort/AbortAll methods

### DIFF
--- a/ControlBee/Interfaces/IDeviceManager.cs
+++ b/ControlBee/Interfaces/IDeviceManager.cs
@@ -9,4 +9,5 @@ public interface IDeviceManager
     void Add(string name, IDevice device);
     IDevice[] GetDevices();
     DeviceMetaInfo GetDeviceMetaInfo(string deviceName);
+    void AbortAll();
 }

--- a/ControlBee/Models/DeviceChannel.cs
+++ b/ControlBee/Models/DeviceChannel.cs
@@ -132,7 +132,7 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
     public virtual void AbortDevice()
     {
         Logger.Info($"Abort device. ({ActorName}, {ItemPath}, {Channel})");
-        GetDeviceMetaInfo().Aborted = true;
+        GetDeviceMetaInfo().Abort();
     }
 
     public void ResetAbort()
@@ -140,7 +140,7 @@ public abstract class DeviceChannel(IDeviceManager deviceManager)
         if (!GetDeviceMetaInfo().Aborted)
             return;
         Logger.Info($"Reset device abort. ({ActorName}, {ItemPath}, {Channel})");
-        GetDeviceMetaInfo().Aborted = false;
+        GetDeviceMetaInfo().ResetAbort();
     }
 
     public virtual void Sync()

--- a/ControlBee/Models/DeviceManager.cs
+++ b/ControlBee/Models/DeviceManager.cs
@@ -1,11 +1,13 @@
 ﻿using ControlBee.Interfaces;
 using ControlBee.Services;
 using ControlBeeAbstract.Devices;
+using log4net;
 
 namespace ControlBee.Models;
 
 public class DeviceManager : IDeviceManager, IDisposable
 {
+    private static readonly ILog Logger = LogManager.GetLogger(nameof(DeviceManager));
     private readonly Dictionary<string, IDevice> _devices = [];
     private readonly IDeviceMetaInfoStore _deviceMetaInfoStore;
 
@@ -44,5 +46,20 @@ public class DeviceManager : IDeviceManager, IDisposable
     public DeviceMetaInfo GetDeviceMetaInfo(string deviceName)
     {
         return _deviceMetaInfoStore.Get(deviceName);
+    }
+
+    public void AbortAll()
+    {
+        foreach (var name in _devices.Keys)
+        {
+            try
+            {
+                GetDeviceMetaInfo(name).Abort();
+            }
+            catch (Exception exception)
+            {
+                Logger.Error($"Failed to abort device. ({name})", exception);
+            }
+        }
     }
 }

--- a/ControlBee/Models/DeviceMetaInfo.cs
+++ b/ControlBee/Models/DeviceMetaInfo.cs
@@ -10,7 +10,17 @@ public class DeviceMetaInfo : INotifyPropertyChanged
     public bool Aborted
     {
         get => _aborted;
-        set => SetField(ref _aborted, value);
+        private set => SetField(ref _aborted, value);
+    }
+
+    public void Abort()
+    {
+        Aborted = true;
+    }
+
+    public void ResetAbort()
+    {
+        Aborted = false;
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/ControlBee/Models/EmptyDeviceManager.cs
+++ b/ControlBee/Models/EmptyDeviceManager.cs
@@ -29,4 +29,6 @@ public class EmptyDeviceManager : IDeviceManager
     {
         return new DeviceMetaInfo();
     }
+
+    public void AbortAll() { }
 }


### PR DESCRIPTION
## What
- `DeviceMetaInfo.Aborted` setter를 private으로 닫고 `Abort()`/`ResetAbort()` 메서드로만 abort 상태를 변경하도록 캡슐화
- `IDeviceManager`에 등록된 전체 디바이스 일괄 abort용 `AbortAll()` 추가
- abort 전파·SafeState 동작은 기존과 동일, 외부 동작 변화 없음

## Why
- `Aborted` setter가 public이라 소비 측에서 프로퍼티 직접 대입으로 abort 가능 → 동사 메서드(`AbortDevice`)라는 의도와 접근 경로 불일치
- 크래시 핸들러 등에서 등록된 모든 디바이스를 SafeState로 몰기 위한 일괄 abort 진입점이 device-layer에 부재 → 소비 측이 `GetDevices()` 순회 + 프로퍼티 직접 set으로 우회 중

## How
- `DeviceMetaInfo.cs`: `Aborted` setter `public` → `private`, `Abort()`(`Aborted=true`)·`ResetAbort()`(`Aborted=false`) 추가
- `DeviceChannel.cs`: `AbortDevice()`/`ResetAbort()`의 프로퍼티 직접 대입 → `Abort()`/`ResetAbort()` 호출로 변경
- `IDeviceManager`에 `void AbortAll()` 추가. `DeviceManager`는 등록된 모든 디바이스에 `Abort()` 적용(디바이스별 try/catch로 best-effort, 실패 시 `Logger.Error`), `EmptyDeviceManager`는 no-op
- setter를 닫는 breaking change → `DeviceMetaInfo.Aborted`에 직접 대입하던 외부 코드는 `Abort()`/`AbortAll()` 호출로 전환 필요
