### PR TITLE
Notify owning actor with _jogEnded when jog motion settles

### DIFF
--- a/ControlBee.Tests/Models/AxisTest.cs
+++ b/ControlBee.Tests/Models/AxisTest.cs
@@ -293,6 +293,67 @@ public class AxisTest : ActorFactoryBase
         actor.Join();
     }
 
+    [Fact]
+    public void JogEndedAfterContinuousJogTest()
+    {
+        var client = MockActorFactory.Create("Client");
+        var actor = ActorFactory.Create<TestActor>("MyActor");
+
+        ActorUtils.SetupActionOnGetMessage(
+            actor,
+            client,
+            "_jogStarted",
+            message => actor.Send(new ActorItemMessage(client, "/X", "_jogStop"))
+        );
+
+        actor.Start();
+        actor.Send(
+            new ActorItemMessage(
+                client,
+                "/X",
+                "_jogStart",
+                new Dict
+                {
+                    ["Type"] = "Continuous",
+                    ["Direction"] = AxisDirection.Positive,
+                    ["JogSpeed"] = JogSpeedLevel.Medium,
+                }
+            )
+        );
+        actor.Join();
+
+        Assert.True(actor.JogEndedReceived);
+        Assert.False(actor.MovingWhenJogEnded);
+    }
+
+    [Fact]
+    public void JogEndedAfterStepJogTest()
+    {
+        var client = MockActorFactory.Create("Client");
+        var actor = ActorFactory.Create<TestActor>("MyActor");
+        ((Axis)actor.X).JogSpeed.Value.Velocity = 1_000_000;
+
+        actor.Start();
+        actor.Send(
+            new ActorItemMessage(
+                client,
+                "/X",
+                "_jogStart",
+                new Dict
+                {
+                    ["Type"] = "Step",
+                    ["Direction"] = AxisDirection.Positive,
+                    ["JogStep"] = JogStep.Large,
+                }
+            )
+        );
+        actor.Join();
+
+        Assert.True(actor.JogEndedReceived);
+        Assert.False(actor.MovingWhenJogEnded);
+        Assert.Equal(110.0, actor.X.GetPosition());
+    }
+
     private IMotionDevice SetupWithDevice()
     {
         SystemPropertiesDataSource.ReadFromString(
@@ -372,6 +433,8 @@ public class AxisTest : ActorFactoryBase
     private class TestActor : Actor
     {
         public readonly IAxis X;
+        public bool JogEndedReceived;
+        public bool MovingWhenJogEnded;
 
         public TestActor(ActorConfig config)
             : base(config)
@@ -403,6 +466,11 @@ public class AxisTest : ActorFactoryBase
                     return true;
                 case "EnableX":
                     X.Enable();
+                    return true;
+                case "_jogEnded":
+                    JogEndedReceived = true;
+                    MovingWhenJogEnded = X.IsMoving();
+                    Send(new TerminateMessage());
                     return true;
             }
 

--- a/ControlBee.Tests/Models/AxisTest.cs
+++ b/ControlBee.Tests/Models/AxisTest.cs
@@ -298,6 +298,7 @@ public class AxisTest : ActorFactoryBase
     {
         var client = MockActorFactory.Create("Client");
         var actor = ActorFactory.Create<TestActor>("MyActor");
+        var clientJogEnded = false;
 
         ActorUtils.SetupActionOnGetMessage(
             actor,
@@ -305,6 +306,7 @@ public class AxisTest : ActorFactoryBase
             "_jogStarted",
             message => actor.Send(new ActorItemMessage(client, "/X", "_jogStop"))
         );
+        ActorUtils.SetupActionOnGetMessage(actor, client, "_jogEnded", _ => clientJogEnded = true);
 
         actor.Start();
         actor.Send(
@@ -322,8 +324,11 @@ public class AxisTest : ActorFactoryBase
         );
         actor.Join();
 
+        Assert.True(actor.JogStartedReceived);
+        Assert.True(actor.JogStoppedReceived);
         Assert.True(actor.JogEndedReceived);
         Assert.False(actor.MovingWhenJogEnded);
+        Assert.True(clientJogEnded);
     }
 
     [Fact]
@@ -332,6 +337,8 @@ public class AxisTest : ActorFactoryBase
         var client = MockActorFactory.Create("Client");
         var actor = ActorFactory.Create<TestActor>("MyActor");
         ((Axis)actor.X).JogSpeed.Value.Velocity = 1_000_000;
+        var clientJogEnded = false;
+        ActorUtils.SetupActionOnGetMessage(actor, client, "_jogEnded", _ => clientJogEnded = true);
 
         actor.Start();
         actor.Send(
@@ -349,9 +356,11 @@ public class AxisTest : ActorFactoryBase
         );
         actor.Join();
 
+        Assert.True(actor.JogStartedReceived);
         Assert.True(actor.JogEndedReceived);
         Assert.False(actor.MovingWhenJogEnded);
         Assert.Equal(110.0, actor.X.GetPosition());
+        Assert.True(clientJogEnded);
     }
 
     private IMotionDevice SetupWithDevice()
@@ -433,6 +442,8 @@ public class AxisTest : ActorFactoryBase
     private class TestActor : Actor
     {
         public readonly IAxis X;
+        public bool JogStartedReceived;
+        public bool JogStoppedReceived;
         public bool JogEndedReceived;
         public bool MovingWhenJogEnded;
 
@@ -466,6 +477,12 @@ public class AxisTest : ActorFactoryBase
                     return true;
                 case "EnableX":
                     X.Enable();
+                    return true;
+                case "_jogStarted":
+                    JogStartedReceived = true;
+                    return true;
+                case "_jogStopped":
+                    JogStoppedReceived = true;
                     return true;
                 case "_jogEnded":
                     JogEndedReceived = true;

--- a/ControlBee/Models/Axis.cs
+++ b/ControlBee/Models/Axis.cs
@@ -271,6 +271,9 @@ public class Axis : DeviceChannel, IAxis
 
                         VelocityMove(direction);
                         message.Sender.Send(new Message(message, Actor, "_jogStarted"));
+                        Actor.Send(
+                            new ActorItemMessage(message.Id, Actor, ItemPath, "_jogStarted")
+                        );
                         break;
                     }
                     case "Step":
@@ -293,7 +296,10 @@ public class Axis : DeviceChannel, IAxis
                         SetSpeed(speed);
                         RelativeMove(step);
                         message.Sender.Send(new Message(message, Actor, "_jogStarted"));
-                        NotifyJogEnded();
+                        Actor.Send(
+                            new ActorItemMessage(message.Id, Actor, ItemPath, "_jogStarted")
+                        );
+                        NotifyJogEnded(message);
                         break;
                     }
                 }
@@ -305,12 +311,15 @@ public class Axis : DeviceChannel, IAxis
                 Logger.Debug("Continuous Jog Stop");
                 Stop();
                 message.Sender.Send(new Message(message, Actor, "_jogStopped"));
-                NotifyJogEnded();
+                Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, "_jogStopped"));
+                NotifyJogEnded(message);
                 return true;
             }
+            case "_jogStarted":
+            case "_jogStopped":
             case "_jogEnded":
-                // Self-notification from NotifyJogEnded; consumed here so the actor's own state
-                // machine may observe it without it being reported as a dropped message.
+                // Self-notifications from the jog handlers; consumed here so the actor's own state
+                // machine may observe them without them being reported as dropped messages.
                 return true;
         }
 
@@ -320,9 +329,10 @@ public class Axis : DeviceChannel, IAxis
     /// <summary>
     ///     Jog motions complete asynchronously (step: after <see cref="RelativeMove" /> returns;
     ///     continuous: while decelerating after <see cref="Stop" />), so watch for standstill in the
-    ///     background and send `_jogEnded` to the owning actor once the axis has settled.
+    ///     background and send `_jogEnded` to both the jog requester and the owning actor once the
+    ///     axis has settled.
     /// </summary>
-    private void NotifyJogEnded()
+    private void NotifyJogEnded(ActorItemMessage message)
     {
         _timeManager.RunTask(() =>
         {
@@ -330,7 +340,8 @@ public class Axis : DeviceChannel, IAxis
             {
                 while (IsMoving())
                     _timeManager.Sleep(1);
-                Actor.Send(new ActorItemMessage(Actor, ItemPath, "_jogEnded"));
+                message.Sender.Send(new Message(message, Actor, "_jogEnded"));
+                Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, "_jogEnded"));
             }
             catch (Exception ex)
             {

--- a/ControlBee/Models/Axis.cs
+++ b/ControlBee/Models/Axis.cs
@@ -293,6 +293,7 @@ public class Axis : DeviceChannel, IAxis
                         SetSpeed(speed);
                         RelativeMove(step);
                         message.Sender.Send(new Message(message, Actor, "_jogStarted"));
+                        NotifyJogEnded();
                         break;
                     }
                 }
@@ -304,11 +305,38 @@ public class Axis : DeviceChannel, IAxis
                 Logger.Debug("Continuous Jog Stop");
                 Stop();
                 message.Sender.Send(new Message(message, Actor, "_jogStopped"));
+                NotifyJogEnded();
                 return true;
             }
+            case "_jogEnded":
+                // Self-notification from NotifyJogEnded; consumed here so the actor's own state
+                // machine may observe it without it being reported as a dropped message.
+                return true;
         }
 
         return base.ProcessMessage(message);
+    }
+
+    /// <summary>
+    ///     Jog motions complete asynchronously (step: after <see cref="RelativeMove" /> returns;
+    ///     continuous: while decelerating after <see cref="Stop" />), so watch for standstill in the
+    ///     background and send `_jogEnded` to the owning actor once the axis has settled.
+    /// </summary>
+    private void NotifyJogEnded()
+    {
+        _timeManager.RunTask(() =>
+        {
+            try
+            {
+                while (IsMoving())
+                    _timeManager.Sleep(1);
+                Actor.Send(new ActorItemMessage(Actor, ItemPath, "_jogEnded"));
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to monitor jog end. ({ActorName}, {ItemPath})", ex);
+            }
+        });
     }
 
     public virtual void Enable(bool value)


### PR DESCRIPTION
## Why

- Jog는 의도적으로 fire-and-forget임: step jog는 `RelativeMove`(논블로킹) 시작 직후 `_jogStarted`를 회신하고, continuous jog의 `_jogStop`도 `Stop()`(정지 명령만 전달) 직후 `_jogStopped`를 회신함. 두 회신 모두 UI(sender)로만 가고, 모션이 실제로 끝난 시점을 알리는 메시지는 어디에도 없음.
- 그래서 축을 소유한 actor는 jog 이후 자기 축의 정착(settle) 시점을 알 수 없음. jog로 움직인 위치에 의존하는 상태를 actor가 publish하는 경우(예: C사 B 프로젝트에서 picker Z가 home 근방인지를 `HomePositionZ`로 publish해 index table 회전 게이트로 사용) 갱신 시점을 잡을 방법이 timer 폴링밖에 없음.
- `_jogStarted`/`_jogStopped` 시점 샘플링은 부정확함: step은 이동 시작 직후(이동 전 값), continuous는 감속 중 값이라 정착값과 다를 수 있음.

## What

- **`Axis`**: jog 모션이 정착하면 소유 actor 자신에게 `_jogEnded`(`ActorItemMessage`, 해당 축 ItemPath)를 보냄. 발생 지점 2곳 —
  - step jog: `_jogStart`(Step)의 `RelativeMove` 직후 감시 시작 → 모션 완료 시 통지
  - continuous jog: `_jogStop`의 `Stop()` 직후 감시 시작 → 감속 완료 시 통지
- **`Axis.ProcessMessage`**: `_jogEnded`를 자체 소비(`return true`) — actor state가 처리하지 않아도 `DroppedMessage` 회신이 나가지 않음. state/actor 레벨에서 함께 handle 하는 것은 자유.
- 기존 코드는 수정 없음 — 순수 추가(+28줄)이며 `_jogStarted`/`_jogStopped` UI 회신, step jog의 already-moving 취소 가드(취소 시 감시 미등록) 등 기존 동작 불변.

Continuous jog의 `_jogStart`에는 감시를 걸지 않음 — 버튼을 누르고 있는 동안 의미 없는 폴링이 돌고, 종료 시점은 어차피 `_jogStop`이 만들기 때문.

일반 `Move`/`MoveAndWait`는 범위 외 — 시퀀스 코드가 직접 호출하므로 완료 시점을 이미 알고 있음. jog만 UI발 비동기라 통지가 필요함.

## How

### 감시 방식 — `_timeManager.RunTask` + `IsMoving()` 폴링

```csharp
private void NotifyJogEnded()
{
    _timeManager.RunTask(() =>
    {
        try
        {
            while (IsMoving())
                _timeManager.Sleep(1);
            Actor.Send(new ActorItemMessage(Actor, ItemPath, "_jogEnded"));
        }
        catch (Exception ex)
        {
            Logger.Error($"Failed to monitor jog end. ({ActorName}, {ItemPath})", ex);
        }
    });
}
```

- 핸들러 안에서 `Wait()`로 대기하는 대안은 불가함: jog 핸들러는 actor 메시지 스레드에서 돌기 때문에, continuous jog는 `_jogStop`을 처리할 스레드가 `Wait()`에 묶여 데드락이고, step jog는 모션 동안 actor가 멎어 fire-and-forget 시맨틱이 깨짐.
- `RunTask` + `Sleep(1)` 폴링은 프레임워크의 기존 패턴 그대로임: `FakeAxis.MonitorMoving`(동일한 IsMoving 폴링), `BinaryActuator.SetOn`, `DigitalOutput`. `RunTask`는 `FrozenTimeManager`에도 구현되어 있어 FakeMode 테스트에서 frozen clock과 함께 동작함(추가한 테스트 2건이 실증).
- 기존 3곳과의 차이는 완료 처리뿐: 기존은 태스크를 `Wait()`가 join, 본 변경은 self-message 전송. 소비자가 actor 메시지 루프라서 join이 아닌 메시지가 맞는 형태임. actor 외부 스레드에서의 `Actor.Send`는 `DeviceMonitor` 스레드가 `RefreshCache` → `SendDataToUi` 경로로 이미 쓰는 방식.
- 공통 헬퍼 추출은 하지 않음: 네 사용처의 공통부는 폴링 루프 2줄뿐이고 타임아웃·abort·완료 시맨틱·태스크 수명이 전부 달라, 일반화 API가 절약분보다 커짐.

### 메시지 설계

- 이름: `_jogStopped`가 이미 "정지 명령 접수" 의미로 UI 회신에 쓰이고 있어, "모션 정착"은 `_jogEnded`로 구분함. 프레임워크 메시지 `_` prefix 컨벤션 준수.
- `ActorItemMessage`에 축 ItemPath를 실어 다축 actor에서 어느 축인지 식별 가능(`_itemDataChanged`와 동일한 방식).

### 알려진 한계 (수용한 trade-off)

- **통지 중복/즉시 발생 가능**: step jog 연타, 정지 상태에서의 `_jogStop` 등에서 `_jogEnded`가 여러 번 또는 즉시 올 수 있음. 통지는 "재샘플링 트리거"이므로 소비 측이 멱등하게 처리하면 됨(중복 억제를 위해 감시 태스크를 단일화하면 태스크 수명 관리가 붙어 복잡도가 더 커짐).
- **감시 태스크에 타임아웃 없음**: `IsMoving()`이 영원히 true면 태스크가 계속 폴링함. `FakeAxis.MonitorMoving`도 동일하게 타임아웃이 없어 프레임워크 기존 판단과 일치시킴.
- **`IsMoving()`이 device 에러로 throw 하면 해당 통지는 유실됨**(로그만 남김). jog 후 재시도나 `_status` 재샘플링으로 소비 측이 보완 가능.