### PR TITLE
Notify requester and owning actor when Position MoveTo* completes

### DIFF
--- a/ControlBee.Tests/Variables/PositionTest.cs
+++ b/ControlBee.Tests/Variables/PositionTest.cs
@@ -29,6 +29,49 @@ public class PositionTest : ActorFactoryBase
     }
 
     [Fact]
+    public void MoveToSavedPos_NotifiesRequesterAndOwningActor()
+    {
+        var client = MockActorFactory.Create("Client");
+        var actor = ActorFactory.Create<TestActor>("MyActor");
+        var clientDone = false;
+        ActorUtils.SetupActionOnGetMessage(
+            actor,
+            client,
+            "MoveToSavedPosDone",
+            _ => clientDone = true
+        );
+
+        actor.Start();
+        actor.Send(new ActorItemMessage(client, "/MyPosition", "MoveToSavedPos"));
+        actor.Join();
+
+        Assert.True(actor.MoveToSavedPosDoneReceived);
+        Assert.True(clientDone);
+        Assert.True(actor.MyPosition.Value.IsNear(1));
+    }
+
+    [Fact]
+    public void MoveToHomePos_NotifiesRequesterAndOwningActor()
+    {
+        var client = MockActorFactory.Create("Client");
+        var actor = ActorFactory.Create<TestActor>("MyActor");
+        var clientDone = false;
+        ActorUtils.SetupActionOnGetMessage(
+            actor,
+            client,
+            "MoveToHomePosDone",
+            _ => clientDone = true
+        );
+
+        actor.Start();
+        actor.Send(new ActorItemMessage(client, "/MyPosition", "MoveToHomePos"));
+        actor.Join();
+
+        Assert.True(actor.MoveToHomePosDoneReceived);
+        Assert.True(clientDone);
+    }
+
+    [Fact]
     public void WaitForPositionTest()
     {
         var actor = ActorFactory.Create<TestActor>("MyActor");
@@ -55,6 +98,8 @@ public class PositionTest : ActorFactoryBase
 
         public readonly IAxis X;
         public readonly IAxis Y;
+        public bool MoveToSavedPosDoneReceived;
+        public bool MoveToHomePosDoneReceived;
 
         public TestActor(ActorConfig config)
             : base(config)
@@ -65,6 +110,23 @@ public class PositionTest : ActorFactoryBase
             PositionAxesMap.Add(MyPosition, [X, Y]);
             X.Enable(true);
             Y.Enable(true);
+        }
+
+        protected override bool ProcessMessage(Message message)
+        {
+            switch (message.Name)
+            {
+                case "MoveToSavedPosDone":
+                    MoveToSavedPosDoneReceived = true;
+                    Send(new TerminateMessage());
+                    break;
+                case "MoveToHomePosDone":
+                    MoveToHomePosDoneReceived = true;
+                    Send(new TerminateMessage());
+                    break;
+            }
+
+            return base.ProcessMessage(message);
         }
 
         protected override void MessageHandler(Message message)

--- a/ControlBee/Variables/Position.cs
+++ b/ControlBee/Variables/Position.cs
@@ -104,12 +104,21 @@ public abstract class Position
         {
             case "MoveToSavedPos":
                 MoveToSavedPos(message);
+                message.Sender.Send(new Message(message, Actor, "MoveToSavedPosDone"));
+                Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, "MoveToSavedPosDone"));
                 return true;
             case "MoveToHomePos":
                 MoveToHomePos();
+                message.Sender.Send(new Message(message, Actor, "MoveToHomePosDone"));
+                Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, "MoveToHomePosDone"));
                 return true;
             case "SetPos":
                 SetPos();
+                return true;
+            case "MoveToSavedPosDone":
+            case "MoveToHomePosDone":
+                // Self-notifications from the MoveTo* handlers; consumed here so the actor's own
+                // state machine may observe them without them being reported as dropped messages.
                 return true;
         }
 

--- a/ControlBee/Variables/Position.cs
+++ b/ControlBee/Variables/Position.cs
@@ -104,13 +104,11 @@ public abstract class Position
         {
             case "MoveToSavedPos":
                 MoveToSavedPos(message);
-                message.Sender.Send(new Message(message, Actor, "MoveToSavedPosDone"));
-                Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, "MoveToSavedPosDone"));
+                NotifyMoveDone(message, "MoveToSavedPosDone");
                 return true;
             case "MoveToHomePos":
                 MoveToHomePos();
-                message.Sender.Send(new Message(message, Actor, "MoveToHomePosDone"));
-                Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, "MoveToHomePosDone"));
+                NotifyMoveDone(message, "MoveToHomePosDone");
                 return true;
             case "SetPos":
                 SetPos();
@@ -123,6 +121,12 @@ public abstract class Position
         }
 
         return false;
+    }
+
+    private void NotifyMoveDone(ActorItemMessage message, string name)
+    {
+        message.Sender.Send(new Message(message, Actor, name));
+        Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, name));
     }
 
     public event EventHandler<ValueChangedArgs>? ValueChanging;

--- a/ControlBee/Variables/Position.cs
+++ b/ControlBee/Variables/Position.cs
@@ -104,11 +104,11 @@ public abstract class Position
         {
             case "MoveToSavedPos":
                 MoveToSavedPos(message);
-                NotifyMoveDone(message, "MoveToSavedPosDone");
+                ReplyWorkDone(message, "MoveToSavedPosDone");
                 return true;
             case "MoveToHomePos":
                 MoveToHomePos();
-                NotifyMoveDone(message, "MoveToHomePosDone");
+                ReplyWorkDone(message, "MoveToHomePosDone");
                 return true;
             case "SetPos":
                 SetPos();
@@ -123,7 +123,7 @@ public abstract class Position
         return false;
     }
 
-    private void NotifyMoveDone(ActorItemMessage message, string name)
+    private void ReplyWorkDone(ActorItemMessage message, string name)
     {
         message.Sender.Send(new Message(message, Actor, name));
         Actor.Send(new ActorItemMessage(message.Id, Actor, ItemPath, name));


### PR DESCRIPTION
## Why

- C사 B 프로젝트에서 `MoveToHomePos`/`MoveToSavedPos`의 완료 시점을 잡기 위해 `base.ProcessMessage()` 리턴 직후에 상태를 갱신하는데, 이는 "base 안에서 Position이 이동을 블로킹으로 끝낸다"는 내부 구현 지식에 의존함. base의 추상화가 감추려는 내용을 파생 클래스가 알고 있는 구조라, 완료를 명시적인 메시지로 분리해야 함.
- jog는 #60에서 `_jogEnded`로 해결했지만, 요청 기반 이동(MoveTo*)에는 완료 메시지가 없음.

## What

- **`Position`**: `MoveToSavedPos`/`MoveToHomePos` 처리 완료 직후 `MoveToSavedPosDone`/`MoveToHomePosDone`을 요청자(sender)와 소유 actor 양쪽에 송신. 자신이 받은 Done 메시지는 자체 소비해 미처리로 집계되지 않게 함(#60의 `_jogEnded`와 같은 방식).

메시지 이름은 리뷰 코멘트의 제안(`MoveToHomePosDone`)을 따름 — Position 메시지 계열(`MoveToSavedPos`, `SetPos`)이 원래 `_` 접두사를 쓰지 않아 그 계열에 맞춤.

## How

### jog와 달리 감시 태스크가 필요 없음

- MoveTo*는 핸들러 안에서 축마다 `MoveAndWait`로 완료까지 실행되므로, 호출이 끝난 지점이 곧 정착 시점임. 처리 끝에서 바로 송신함.

### 수신자별 메시지 형태 — #60과 동일한 기준

- 요청자에게는 기존 회신 관례대로 requestId를 이어받은 `Message`.
- 소유 actor에게는 `ActorItemMessage` — item으로 라우팅되어야 Position이 자체 소비할 수 있고, 덕분에 어떤 actor에서도 별도 처리 없이 `DroppedMessage` 회신이 발생하지 않음. 관심 있는 actor만 자기 `ProcessMessage`에서 관찰하면 됨.


## Question

`Variable.ProcessMessage`가 subItem의 반환값을 버리는 것이 의도된 설계인지 확인 부탁드립니다.
``` csharp
public override bool ProcessMessage(ActorItemMessage message)
{
    ...

    var ret = base.ProcessMessage(message);
    if (_value is IActorItemSub actorItemSub)
        actorItemSub.ProcessMessage(message);

    return ret;
}
```

위 코드에서
``` csharp
if (_value is IActorItemSub actorItemSub)
    ret |= actorItemSub.ProcessMessage(message);
```

형태로 변경하여 `MoveTo...Pos` message 를 처리하고 dropped message 를 발행하지 않아야 하는지 궁금합니다