### PR TITLE
Split binary actuator timeout error by direction

### DIFF
--- a/ControlBee.Tests/Models/BinaryActuatorTest.cs
+++ b/ControlBee.Tests/Models/BinaryActuatorTest.cs
@@ -40,9 +40,54 @@ public class BinaryActuatorTest
         actor.Send(new Message(EmptyActor.Instance, "_terminate"));
         actor.Join();
 
-        var match = new Func<Message, bool>(message => message.Name == "_displayDialog");
+        var match = new Func<Message, bool>(message =>
+            message.Name == "_displayDialog"
+            && ((IDialogContext)message.Payload!).ItemPath == "/Cyl1/OnTimeoutError"
+        );
         Mock.Get(ui).Verify(m => m.Send(It.Is<Message>(message => match(message))), Times.Once);
         Assert.True(TimeManager.CurrentMilliseconds >= 5000);
+    }
+
+    [Fact]
+    public void OffTimeoutTest()
+    {
+        var config = new ActorFactoryBaseConfig
+        {
+            SystemConfigurations = new SystemConfigurations { FakeMode = false },
+        };
+        Recreate(config);
+
+        SystemPropertiesDataSource.ReadFromString(
+            """
+              myActor:
+                CylFwdDet1:
+                  DeviceName: MyDevice
+                  Channel: 0
+                CylBwdDet1:
+                  DeviceName: MyDevice
+                  Channel: 2
+            """
+        );
+        var device = Mock.Of<IDigitalIoDevice>();
+        DeviceManager.Add("MyDevice", device);
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(0)).Returns(true);
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(2)).Returns(false);
+
+        var ui = Mock.Of<IUiActor>();
+        Mock.Get(ui).Setup(m => m.Name).Returns("Ui");
+        ActorRegistry.Add(ui);
+        var actor = ActorFactory.Create<TestActor>("myActor");
+
+        actor.Start();
+        actor.Send(new Message(EmptyActor.Instance, "OnOff1"));
+        actor.Send(new Message(EmptyActor.Instance, "_terminate"));
+        actor.Join();
+
+        var match = new Func<Message, bool>(message =>
+            message.Name == "_displayDialog"
+            && ((IDialogContext)message.Payload!).ItemPath == "/Cyl1/OffTimeoutError"
+        );
+        Mock.Get(ui).Verify(m => m.Send(It.Is<Message>(message => match(message))), Times.Once);
     }
 
     [Fact]
@@ -380,6 +425,18 @@ public class BinaryActuatorTest
                 case "OnAndOff":
                     Cyl1.OnAndWait();
                     Cyl1.OffAndWait();
+                    return true;
+
+                case "OnOff1":
+                    try
+                    {
+                        Cyl1.OnAndWait();
+                        Cyl1.OffAndWait();
+                    }
+                    catch (TimeoutError)
+                    {
+                        // Alert trigger will be checked.
+                    }
                     return true;
 
                 case "OnBoth":

--- a/ControlBee/Models/BinaryActuator.cs
+++ b/ControlBee/Models/BinaryActuator.cs
@@ -21,8 +21,16 @@ public class BinaryActuator : ActorItem, IBinaryActuator
     private IDigitalOutput? _outputOff;
     private IDigitalOutput? _outputOn;
 
-    private Task<bool>? _task;
-    public IDialog TimeoutError = new DialogPlaceholder();
+    private Task<ActuationResult>? _task;
+    public IDialog OnTimeoutError = new DialogPlaceholder();
+    public IDialog OffTimeoutError = new DialogPlaceholder();
+
+    private enum ActuationResult
+    {
+        Completed,
+        TimedOut,
+        Aborted,
+    }
 
     public BinaryActuator(
         ISystemConfigurations systemConfigurations,
@@ -90,11 +98,13 @@ public class BinaryActuator : ActorItem, IBinaryActuator
                 // ReSharper disable InvertIf
                 if (_task is { IsCompleted: true })
                 {
-                    var success = _task.Result;
+                    var result = _task.Result;
                     _task = null;
-                    if (!success)
+                    if (result == ActuationResult.Aborted)
+                        throw new DeviceAbortedError();
+                    if (result == ActuationResult.TimedOut)
                     {
-                        TimeoutError.Show();
+                        (CommandOn ? OnTimeoutError : OffTimeoutError).Show();
                         throw new TimeoutError();
                     }
                 }
@@ -218,7 +228,7 @@ public class BinaryActuator : ActorItem, IBinaryActuator
             while (true)
             {
                 if (IsAborted())
-                    return false;
+                    return ActuationResult.Aborted;
                 if (CommandOn && OnDetect())
                     break;
                 if (!CommandOn && OffDetect())
@@ -226,7 +236,7 @@ public class BinaryActuator : ActorItem, IBinaryActuator
                 if (_inputOn == null && _inputOff == null)
                     break;
                 if (watch.ElapsedMilliseconds >= timeout)
-                    return false;
+                    return ActuationResult.TimedOut;
 
                 _timeManager.Sleep(1);
                 _scenarioFlowTester.OnCheckpoint();
@@ -235,7 +245,7 @@ public class BinaryActuator : ActorItem, IBinaryActuator
             _timeManager.Sleep(delay);
 
             ActualOn = CommandOn;
-            return true;
+            return ActuationResult.Completed;
         });
     }
 


### PR DESCRIPTION
## What

- **`BinaryActuator`**: `TimeoutError` dialog를 `OnTimeoutError`/`OffTimeoutError`로 분리. 실패한 방향의 dialog만 표시되므로 검출 입력이 한쪽에만 달린 actuator에서도 어느 동작이 실패했는지 드러남
- **`BinaryActuator`**: abort로 중단된 경우 타임아웃 알람 대신 `DeviceAbortedError` 발생
- Breaking change — `{Actuator}/TimeoutError`로 알람을 정의한 프로젝트는 `OnTimeoutError`/`OffTimeoutError`로 옮겨야 함. 정의하지 않은 프로젝트는 기존과 동일(알람 내용 없이 표시)

## Why

- `BinaryActuator`는 타임아웃 시간은 `OnTimeout`/`OffTimeout` Variable로 방향별로 구분해 쓰면서(`on ? OnTimeout.Value : OffTimeout.Value`), 실패를 알리는 dialog는 `TimeoutError` 하나뿐임. On/Off 중 어느 방향으로 가다 실패했는지 알람으로 구별할 수 없어 알람 문구를 양방향 공용으로 뭉뚱그릴 수밖에 없음
- actuation task가 timeout과 abort를 모두 `false`로 반환해, `Wait()`를 거치지 않고 `IsOn()`을 직접 호출하는 경로에서는 abort가 타임아웃 알람으로 표시됨

## How

- `TimeoutError` 필드 제거 → `OnTimeoutError`, `OffTimeoutError` 추가. `IsOn(Actual)`에서 `CommandOn ? OnTimeoutError : OffTimeoutError`로 선택해 `Show()`
- actuation task 반환을 `bool` → `ActuationResult{Completed, TimedOut, Aborted}`로 변경. `IsOn(Actual)`에서 `Aborted`는 `DeviceAbortedError`, `TimedOut`은 dialog 표시 후 `TimeoutError` throw
- `BinaryActuatorTest`: 기존 `TimeoutTest`가 표시된 dialog의 ItemPath(`/Cyl1/OnTimeoutError`)까지 검증하도록 강화, Off 방향 실패용 `OffTimeoutTest` 추가

## 의견

actuator에 dialog를 새로 두는 대신, `_inputOn`/`_inputOff`가 이미 갖고 있는 `DigitalInput.OnTimeoutError`/`OffTimeoutError`를 그대로 재사용하는 방향도 검토했음. 어느 쪽이 나은지 의견 필요.

- 재사용 시 이점: actuator에 dialog 필드를 늘리지 않아도 되고, 알람이 물리 센서에 귀속되어 어느 센서를 확인해야 하는지가 알람 단위로 명확해짐
- 걸리는 점: `IDigitalInput`에 dialog 접근 수단을 뚫어야함. 그리고 Actuator는 input의 wait on,off를 사용하지않고, 직접 폴링함.
- 이번 PR은 actuator 소유로 구현했으나, 센서 단위 알람이 운영상 더 낫다면 재사용 방향으로 바꿀 수 있음
