### PR TITLE
Let BinaryActuator take multiple on/off detector inputs

### DIFF
--- a/ControlBee.Tests/Models/BinaryActuatorTest.cs
+++ b/ControlBee.Tests/Models/BinaryActuatorTest.cs
@@ -405,4 +405,225 @@ public class BinaryActuatorTest
             return base.ProcessMessage(message);
         }
     }
+
+    [Fact]
+    public void OnAndWaitMultipleInputsTest()
+    {
+        var config = new ActorFactoryBaseConfig
+        {
+            SystemConfigurations = new SystemConfigurations { FakeMode = false },
+        };
+        Recreate(config);
+
+        var device = SetupMultipleInputDevice();
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(0)).Returns(false);
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(1)).Returns(false);
+        var actor = ActorFactory.Create<MultipleInputTestActor>("myActor");
+        ScenarioFlowTester.Setup([
+            [
+                // ReSharper disable once AccessToDisposedClosure
+                new ConditionStep(() => TimeManager.CurrentMilliseconds > 1000),
+                new BehaviorStep(() =>
+                    Mock.Get(device).Setup(m => m.GetDigitalInputBit(0)).Returns(true)
+                ),
+                new BehaviorStep(() => Assert.Null(actor.Cyl.IsOn())),
+                new ConditionStep(() => TimeManager.CurrentMilliseconds > 2000),
+                new BehaviorStep(() =>
+                    Mock.Get(device).Setup(m => m.GetDigitalInputBit(1)).Returns(true)
+                ),
+            ],
+        ]);
+
+        actor.Start();
+        actor.Send(new Message(EmptyActor.Instance, "On"));
+        actor.Send(new Message(EmptyActor.Instance, "_terminate"));
+        actor.Join();
+
+        Assert.True(actor.Cyl.IsOn());
+        Assert.True(ScenarioFlowTester.Complete);
+        Assert.True(TimeManager.CurrentMilliseconds is > 2000 and < 3000);
+    }
+
+    [Fact]
+    public void OnAndWaitMultipleInputsTimeoutTest()
+    {
+        var config = new ActorFactoryBaseConfig
+        {
+            SystemConfigurations = new SystemConfigurations { FakeMode = false },
+        };
+        Recreate(config);
+
+        var device = SetupMultipleInputDevice();
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(0)).Returns(false);
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(1)).Returns(false);
+
+        var ui = Mock.Of<IUiActor>();
+        Mock.Get(ui).Setup(m => m.Name).Returns("Ui");
+        ActorRegistry.Add(ui);
+        var actor = ActorFactory.Create<MultipleInputTestActor>("myActor");
+        ScenarioFlowTester.Setup([
+            [
+                // ReSharper disable once AccessToDisposedClosure
+                new ConditionStep(() => TimeManager.CurrentMilliseconds > 1000),
+                new BehaviorStep(() =>
+                    Mock.Get(device).Setup(m => m.GetDigitalInputBit(0)).Returns(true)
+                ),
+            ],
+        ]);
+
+        actor.Start();
+        actor.Send(new Message(EmptyActor.Instance, "On"));
+        actor.Send(new Message(EmptyActor.Instance, "_terminate"));
+        actor.Join();
+
+        var match = new Func<Message, bool>(message => message.Name == "_displayDialog");
+        Mock.Get(ui).Verify(m => m.Send(It.Is<Message>(message => match(message))), Times.Once);
+        Assert.True(ScenarioFlowTester.Complete);
+        Assert.True(TimeManager.CurrentMilliseconds >= 5000);
+    }
+
+    [Fact]
+    public void OffAndWaitMultipleInputsTest()
+    {
+        var config = new ActorFactoryBaseConfig
+        {
+            SystemConfigurations = new SystemConfigurations { FakeMode = false },
+        };
+        Recreate(config);
+
+        var device = SetupMultipleInputDevice();
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(2)).Returns(false);
+        Mock.Get(device).Setup(m => m.GetDigitalInputBit(3)).Returns(false);
+        var actor = ActorFactory.Create<MultipleInputTestActor>("myActor");
+        ScenarioFlowTester.Setup([
+            [
+                // ReSharper disable once AccessToDisposedClosure
+                new ConditionStep(() => TimeManager.CurrentMilliseconds > 1000),
+                new BehaviorStep(() =>
+                    Mock.Get(device).Setup(m => m.GetDigitalInputBit(2)).Returns(true)
+                ),
+                new BehaviorStep(() => Assert.Null(actor.Cyl.IsOff())),
+                new ConditionStep(() => TimeManager.CurrentMilliseconds > 2000),
+                new BehaviorStep(() =>
+                    Mock.Get(device).Setup(m => m.GetDigitalInputBit(3)).Returns(true)
+                ),
+            ],
+        ]);
+
+        actor.Start();
+        actor.Send(new Message(EmptyActor.Instance, "Off"));
+        actor.Send(new Message(EmptyActor.Instance, "_terminate"));
+        actor.Join();
+
+        Assert.True(actor.Cyl.IsOff());
+        Assert.True(ScenarioFlowTester.Complete);
+        Assert.True(TimeManager.CurrentMilliseconds is > 2000 and < 3000);
+    }
+
+    [Fact]
+    public void MultipleFakeDigitalInputsTest()
+    {
+        var config = new ActorFactoryBaseConfig
+        {
+            SystemConfigurations = new SystemConfigurations { FakeMode = true },
+        };
+        Recreate(config);
+
+        var actor = ActorFactory.Create<MultipleInputTestActor>("myActor");
+
+        actor.Start();
+        actor.Send(new Message(EmptyActor.Instance, "On"));
+        actor.Send(new Message(EmptyActor.Instance, "_terminate"));
+        actor.Join();
+
+        var inputOn1 = Assert.IsType<FakeDigitalInput>(actor.CylFwdDet1);
+        var inputOn2 = Assert.IsType<FakeDigitalInput>(actor.CylFwdDet2);
+        var inputOff1 = Assert.IsType<FakeDigitalInput>(actor.CylBwdDet1);
+        var inputOff2 = Assert.IsType<FakeDigitalInput>(actor.CylBwdDet2);
+        Assert.True(inputOn1.IsOn());
+        Assert.True(inputOn2.IsOn());
+        Assert.True(inputOff1.IsOff());
+        Assert.True(inputOff2.IsOff());
+    }
+
+    private IDigitalIoDevice SetupMultipleInputDevice()
+    {
+        SystemPropertiesDataSource.ReadFromString(
+            """
+              myActor:
+                CylFwdDet1:
+                  DeviceName: MyDevice
+                  Channel: 0
+                CylFwdDet2:
+                  DeviceName: MyDevice
+                  Channel: 1
+                CylBwdDet1:
+                  DeviceName: MyDevice
+                  Channel: 2
+                CylBwdDet2:
+                  DeviceName: MyDevice
+                  Channel: 3
+            """
+        );
+
+        var device = Mock.Of<IDigitalIoDevice>();
+        DeviceManager.Add("MyDevice", device);
+        return device;
+    }
+
+    private class MultipleInputTestActor : Actor
+    {
+        public readonly IBinaryActuator Cyl;
+        public readonly IDigitalOutput CylBwd = new DigitalOutputPlaceholder();
+        public readonly IDigitalInput CylBwdDet1 = new DigitalInputPlaceholder();
+        public readonly IDigitalInput CylBwdDet2 = new DigitalInputPlaceholder();
+        public readonly IDigitalOutput CylFwd = new DigitalOutputPlaceholder();
+        public readonly IDigitalInput CylFwdDet1 = new DigitalInputPlaceholder();
+        public readonly IDigitalInput CylFwdDet2 = new DigitalInputPlaceholder();
+
+        public MultipleInputTestActor(ActorConfig config)
+            : base(config)
+        {
+            Cyl = config.BinaryActuatorFactory.Create(
+                CylFwd,
+                CylBwd,
+                [CylFwdDet1, CylFwdDet2],
+                [CylBwdDet1, CylBwdDet2]
+            );
+        }
+
+        protected override IState CreateErrorState(SequenceError error)
+        {
+            return new ErrorState<MultipleInputTestActor>(this, error);
+        }
+
+        protected override bool ProcessMessage(Message message)
+        {
+            switch (message.Name)
+            {
+                case "On":
+                    try
+                    {
+                        Cyl.OnAndWait();
+                    }
+                    catch (TimeoutError)
+                    {
+                        // Alert trigger will be checked.
+                    }
+                    return true;
+                case "Off":
+                    try
+                    {
+                        Cyl.OffAndWait();
+                    }
+                    catch (TimeoutError)
+                    {
+                        // Alert trigger will be checked.
+                    }
+                    return true;
+            }
+
+            return base.ProcessMessage(message);
+        }
+    }
 }

--- a/ControlBee.Tests/Models/BinaryActuatorTest.cs
+++ b/ControlBee.Tests/Models/BinaryActuatorTest.cs
@@ -626,4 +626,65 @@ public class BinaryActuatorTest
             return base.ProcessMessage(message);
         }
     }
+
+    [Fact]
+    public void MultipleInputsNullTest()
+    {
+        var config = new ActorFactoryBaseConfig
+        {
+            SystemConfigurations = new SystemConfigurations { FakeMode = false },
+        };
+        Recreate(config);
+
+        var ui = Mock.Of<IUiActor>();
+        Mock.Get(ui).Setup(m => m.Name).Returns("Ui");
+        ActorRegistry.Add(ui);
+        var actor = ActorFactory.Create<NullMultipleInputTestActor>("myActor");
+
+        actor.Start();
+        actor.Send(new Message(EmptyActor.Instance, "On"));
+        actor.Send(new Message(EmptyActor.Instance, "_terminate"));
+        actor.Join();
+
+        Assert.True(actor.Cyl.IsOn());
+        Assert.False(actor.Cyl.OnDetect());
+        Assert.False(actor.Cyl.OffDetect());
+        var match = new Func<Message, bool>(message => message.Name == "_displayDialog");
+        Mock.Get(ui).Verify(m => m.Send(It.Is<Message>(message => match(message))), Times.Never);
+        Assert.True(TimeManager.CurrentMilliseconds < 1000);
+    }
+
+    private class NullMultipleInputTestActor : Actor
+    {
+        public readonly IBinaryActuator Cyl;
+        public readonly IDigitalOutput CylBwd = new DigitalOutputPlaceholder();
+        public readonly IDigitalOutput CylFwd = new DigitalOutputPlaceholder();
+
+        public NullMultipleInputTestActor(ActorConfig config)
+            : base(config)
+        {
+            Cyl = config.BinaryActuatorFactory.Create(
+                CylFwd,
+                CylBwd,
+                (IDigitalInput[]?)null,
+                (IDigitalInput[]?)null
+            );
+        }
+
+        protected override IState CreateErrorState(SequenceError error)
+        {
+            return new ErrorState<NullMultipleInputTestActor>(this, error);
+        }
+
+        protected override bool ProcessMessage(Message message)
+        {
+            if (message.Name == "On")
+            {
+                Cyl.OnAndWait();
+                return true;
+            }
+
+            return base.ProcessMessage(message);
+        }
+    }
 }

--- a/ControlBee/Interfaces/IBinaryActuatorFactory.cs
+++ b/ControlBee/Interfaces/IBinaryActuatorFactory.cs
@@ -8,4 +8,11 @@ public interface IBinaryActuatorFactory
         IDigitalInput? inputOn,
         IDigitalInput? inputOff
     );
+
+    IBinaryActuator Create(
+        IDigitalOutput? outputOn,
+        IDigitalOutput? outputOff,
+        IDigitalInput[] inputsOn,
+        IDigitalInput[] inputsOff
+    );
 }

--- a/ControlBee/Interfaces/IBinaryActuatorFactory.cs
+++ b/ControlBee/Interfaces/IBinaryActuatorFactory.cs
@@ -12,7 +12,7 @@ public interface IBinaryActuatorFactory
     IBinaryActuator Create(
         IDigitalOutput? outputOn,
         IDigitalOutput? outputOff,
-        IDigitalInput[] inputsOn,
-        IDigitalInput[] inputsOff
+        IDigitalInput[]? inputsOn,
+        IDigitalInput[]? inputsOff
     );
 }

--- a/ControlBee/Models/BinaryActuator.cs
+++ b/ControlBee/Models/BinaryActuator.cs
@@ -39,8 +39,8 @@ public class BinaryActuator : ActorItem, IBinaryActuator
             scenarioFlowTester,
             outputOn,
             outputOff,
-            inputOn == null ? Array.Empty<IDigitalInput>() : new[] { inputOn },
-            inputOff == null ? Array.Empty<IDigitalInput>() : new[] { inputOff }
+            inputOn == null ? null : [inputOn],
+            inputOff == null ? null : [inputOff]
         ) { }
 
     public BinaryActuator(
@@ -49,8 +49,8 @@ public class BinaryActuator : ActorItem, IBinaryActuator
         IScenarioFlowTester scenarioFlowTester,
         IDigitalOutput? outputOn,
         IDigitalOutput? outputOff,
-        IDigitalInput[] inputsOn,
-        IDigitalInput[] inputsOff
+        IDigitalInput[]? inputsOn,
+        IDigitalInput[]? inputsOff
     )
     {
         _systemConfigurations = systemConfigurations;
@@ -58,8 +58,8 @@ public class BinaryActuator : ActorItem, IBinaryActuator
         _scenarioFlowTester = scenarioFlowTester;
         _outputOn = outputOn;
         _outputOff = outputOff;
-        _inputsOn = inputsOn;
-        _inputsOff = inputsOff;
+        _inputsOn = inputsOn ?? [];
+        _inputsOff = inputsOff ?? [];
         var timeoutScope = systemConfigurations.UseLocalTimeouts
             ? VariableScope.Local
             : VariableScope.Global;

--- a/ControlBee/Models/BinaryActuator.cs
+++ b/ControlBee/Models/BinaryActuator.cs
@@ -13,8 +13,8 @@ public class BinaryActuator : ActorItem, IBinaryActuator
     private readonly IScenarioFlowTester _scenarioFlowTester;
     private readonly ISystemConfigurations _systemConfigurations;
     private readonly ITimeManager _timeManager;
-    private IDigitalInput? _inputOff;
-    private IDigitalInput? _inputOn;
+    private IDigitalInput[] _inputsOn;
+    private IDigitalInput[] _inputsOff;
 
     private bool? _actualOn;
     private bool _commandOn;
@@ -33,14 +33,33 @@ public class BinaryActuator : ActorItem, IBinaryActuator
         IDigitalInput? inputOn,
         IDigitalInput? inputOff
     )
+        : this(
+            systemConfigurations,
+            timeManager,
+            scenarioFlowTester,
+            outputOn,
+            outputOff,
+            inputOn == null ? Array.Empty<IDigitalInput>() : new[] { inputOn },
+            inputOff == null ? Array.Empty<IDigitalInput>() : new[] { inputOff }
+        ) { }
+
+    public BinaryActuator(
+        ISystemConfigurations systemConfigurations,
+        ITimeManager timeManager,
+        IScenarioFlowTester scenarioFlowTester,
+        IDigitalOutput? outputOn,
+        IDigitalOutput? outputOff,
+        IDigitalInput[] inputsOn,
+        IDigitalInput[] inputsOff
+    )
     {
         _systemConfigurations = systemConfigurations;
         _timeManager = timeManager;
         _scenarioFlowTester = scenarioFlowTester;
         _outputOn = outputOn;
         _outputOff = outputOff;
-        _inputOn = inputOn;
-        _inputOff = inputOff;
+        _inputsOn = inputsOn;
+        _inputsOff = inputsOff;
         var timeoutScope = systemConfigurations.UseLocalTimeouts
             ? VariableScope.Local
             : VariableScope.Global;
@@ -113,12 +132,20 @@ public class BinaryActuator : ActorItem, IBinaryActuator
 
     public bool OnDetect()
     {
-        return _inputOn?.IsOnOrTrue() ?? _inputOff?.IsOffOrTrue() ?? false;
+        if (_inputsOn.Length > 0)
+            return _inputsOn.All(x => x.IsOnOrTrue());
+        if (_inputsOff.Length > 0)
+            return _inputsOff.All(x => x.IsOffOrTrue());
+        return false;
     }
 
     public bool OffDetect()
     {
-        return _inputOff?.IsOnOrTrue() ?? _inputOn?.IsOffOrTrue() ?? false;
+        if (_inputsOff.Length > 0)
+            return _inputsOff.All(x => x.IsOnOrTrue());
+        if (_inputsOn.Length > 0)
+            return _inputsOn.All(x => x.IsOffOrTrue());
+        return false;
     }
 
     public void OnAndWait()
@@ -157,8 +184,10 @@ public class BinaryActuator : ActorItem, IBinaryActuator
         Unsubscribe();
         _outputOn = manager.TryGet(_outputOn);
         _outputOff = manager.TryGet(_outputOff);
-        _inputOn = manager.TryGet(_inputOn);
-        _inputOff = manager.TryGet(_inputOff);
+        for (var i = 0; i < _inputsOn.Length; i++)
+            _inputsOn[i] = manager.TryGet(_inputsOn[i]);
+        for (var i = 0; i < _inputsOff.Length; i++)
+            _inputsOff[i] = manager.TryGet(_inputsOff[i]);
         Subscribe();
     }
 
@@ -205,10 +234,12 @@ public class BinaryActuator : ActorItem, IBinaryActuator
         CommandOn = on;
         _outputOn?.SetOn(CommandOn);
         _outputOff?.SetOn(!CommandOn);
-        if (_inputOn is FakeDigitalInput fakeInputOn)
-            fakeInputOn.On = on;
-        if (_inputOff is FakeDigitalInput fakeInputOff)
-            fakeInputOff.On = !on;
+        foreach (var inputOn in _inputsOn)
+            if (inputOn is FakeDigitalInput fakeInputOn)
+                fakeInputOn.On = on;
+        foreach (var inputOff in _inputsOff)
+            if (inputOff is FakeDigitalInput fakeInputOff)
+                fakeInputOff.On = !on;
 
         var delay = on ? OnDelay.Value : OffDelay.Value;
         var timeout = on ? OnTimeout.Value : OffTimeout.Value;
@@ -223,7 +254,7 @@ public class BinaryActuator : ActorItem, IBinaryActuator
                     break;
                 if (!CommandOn && OffDetect())
                     break;
-                if (_inputOn == null && _inputOff == null)
+                if (_inputsOn.Length == 0 && _inputsOff.Length == 0)
                     break;
                 if (watch.ElapsedMilliseconds >= timeout)
                     return false;
@@ -241,18 +272,18 @@ public class BinaryActuator : ActorItem, IBinaryActuator
 
     private void Unsubscribe()
     {
-        if (_inputOff != null)
-            _inputOff.ActualOnChanged -= InputOffOnActualOnChanged;
-        if (_inputOn != null)
-            _inputOn.ActualOnChanged -= InputOffOnActualOnChanged;
+        foreach (var inputOff in _inputsOff)
+            inputOff.ActualOnChanged -= InputOffOnActualOnChanged;
+        foreach (var inputOn in _inputsOn)
+            inputOn.ActualOnChanged -= InputOffOnActualOnChanged;
     }
 
     private void Subscribe()
     {
-        if (_inputOff != null)
-            _inputOff.ActualOnChanged += InputOffOnActualOnChanged;
-        if (_inputOn != null)
-            _inputOn.ActualOnChanged += InputOffOnActualOnChanged;
+        foreach (var inputOff in _inputsOff)
+            inputOff.ActualOnChanged += InputOffOnActualOnChanged;
+        foreach (var inputOn in _inputsOn)
+            inputOn.ActualOnChanged += InputOffOnActualOnChanged;
     }
 
     private void InputOffOnActualOnChanged(object? sender, bool e)

--- a/ControlBee/Models/BinaryActuatorFactory.cs
+++ b/ControlBee/Models/BinaryActuatorFactory.cs
@@ -25,4 +25,22 @@ public class BinaryActuatorFactory(
             inputOff
         );
     }
+
+    public IBinaryActuator Create(
+        IDigitalOutput? outputOn,
+        IDigitalOutput? outputOff,
+        IDigitalInput[] inputsOn,
+        IDigitalInput[] inputsOff
+    )
+    {
+        return new BinaryActuator(
+            systemConfigurations,
+            timeManager,
+            scenarioFlowTester,
+            outputOn,
+            outputOff,
+            inputsOn,
+            inputsOff
+        );
+    }
 }

--- a/ControlBee/Models/BinaryActuatorFactory.cs
+++ b/ControlBee/Models/BinaryActuatorFactory.cs
@@ -29,8 +29,8 @@ public class BinaryActuatorFactory(
     public IBinaryActuator Create(
         IDigitalOutput? outputOn,
         IDigitalOutput? outputOff,
-        IDigitalInput[] inputsOn,
-        IDigitalInput[] inputsOff
+        IDigitalInput[]? inputsOn,
+        IDigitalInput[]? inputsOff
     )
     {
         return new BinaryActuator(

--- a/ControlBee/Models/EmptyBinaryActuatorFactory.cs
+++ b/ControlBee/Models/EmptyBinaryActuatorFactory.cs
@@ -18,4 +18,14 @@ public class EmptyBinaryActuatorFactory : IBinaryActuatorFactory
     {
         throw new UnimplementedByDesignError();
     }
+
+    public IBinaryActuator Create(
+        IDigitalOutput? outputOn,
+        IDigitalOutput? outputOff,
+        IDigitalInput[] inputsOn,
+        IDigitalInput[] inputsOff
+    )
+    {
+        throw new UnimplementedByDesignError();
+    }
 }

--- a/ControlBee/Models/EmptyBinaryActuatorFactory.cs
+++ b/ControlBee/Models/EmptyBinaryActuatorFactory.cs
@@ -22,8 +22,8 @@ public class EmptyBinaryActuatorFactory : IBinaryActuatorFactory
     public IBinaryActuator Create(
         IDigitalOutput? outputOn,
         IDigitalOutput? outputOff,
-        IDigitalInput[] inputsOn,
-        IDigitalInput[] inputsOff
+        IDigitalInput[]? inputsOn,
+        IDigitalInput[]? inputsOff
     )
     {
         throw new UnimplementedByDesignError();


### PR DESCRIPTION
## What
- `BinaryActuator`에 on/off 감지 입력을 배열로 받는 생성자와 `IBinaryActuatorFactory.Create` 오버로드 추가
- 기존 단일 입력 API는 그대로 동작함. 기존 소비처 수정 없음

## Why
- 실린더 output은 한개이지만  on off 감지하는 input 센서가 각각 2개 이상인 IO가 여럿 보고됨. 감지가 1:1 짝이 아니라 `BinaryActuator`를 선언할 수 없음

## How
- 감지 필드를 `IDigitalInput?` 2개에서 `IDigitalInput[]` 2개로 변경. 기존 단일 입력 생성자는 1원소 배열로 새 생성자에 위임
- 배열 인자는 null 허용. 생성자가 빈 배열로 정규화하므로 "없으면 null"이라는 기존 호출 관례가 배열 오버로드에서도 그대로 유지됨
- `OnDetect()`/`OffDetect()`는 감지 전부가 만족해야 true. 감지가 하나일 때의 판정은 기존과 동일
- Fake 입력 세팅, placeholder 교체, 이벤트 구독, 감지 없음 즉시 탈출 조건을 배열 순회로 변경
- 테스트 5건 추가(다중 감지 도달, 한쪽 미도달 타임아웃, off 대칭, Fake 세팅, 배열 오버로드 null 정규화). 기존 테스트는 무수정
- 감지 인자 둘 다 null 리터럴인 호출은 두 오버로드 사이에서 모호성 컴파일 에러가 남. 현재 소비처에는 해당 호출이 없음을 확인함
